### PR TITLE
Reached first usability milestone: Create a dataset of 50 synthetic recordings and render it massively

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ factors.
          - Frames appear synced, however when compared to real-world footage there is a speed scaling issue...
     - [x] Validate "Replay episode" works as expected with episodes collected in Isaac Sim
     - [x] Investigate high latency in myarm loop (it is higher than in lerobot branch)
-    - [ ] Better calibrate robots so they match position in sim to real world
+    - [x] Better calibrate robots so they match position in sim to real world
     - [x] Record position of articulator in sim, not just real robot joints
     - [x] Fix bug with myarm firmware where there's a singularity at the 0 point
+    - [ ] Actually collect 50 samples
   - [x] Create a RobotProtocol that emulates latency and speed of my real robot
-  - [x] Collect a small real dataset for cube->basket task
+  - [ ] Collect a small real dataset for cube->basket task
   - [ ] Train a model on synthetic data, fine-tune on real data
   - [x] Train a model on real data]
   - [ ] Compare performance of model trained on synthetic data vs real data

--- a/README.md
+++ b/README.md
@@ -45,17 +45,17 @@ factors.
     - [x] Validate frames are synced as expected, for example, when the robot starts moving in the opposite direction
          - Frames appear synced, however when compared to real-world footage there is a speed scaling issue...
     - [x] Validate "Replay episode" works as expected with episodes collected in Isaac Sim
+    - [x] Investigate high latency in myarm loop (it is higher than in lerobot branch)
     - [ ] Better calibrate robots so they match position in sim to real world
     - [x] Record position of articulator in sim, not just real robot joints
     - [x] Fix bug with myarm firmware where there's a singularity at the 0 point
-    - [ ] Investigate high latency in myarm loop (it is higher than in lerobot branch)
   - [x] Create a RobotProtocol that emulates latency and speed of my real robot
   - [x] Collect a small real dataset for cube->basket task
   - [ ] Train a model on synthetic data, fine-tune on real data
   - [x] Train a model on real data]
   - [ ] Compare performance of model trained on synthetic data vs real data
 - [ ] Create & Document easy workflows for:
-  - [ ] Record demonstrations with **real leader arm** and **simulation follower arm**
+  - [ ] Record demonstrations with **real le[dirview.py](../../../../../dirview.py)ader arm** and **simulation follower arm**
   - [x] Multiplex demonstrations using domain randomization, leveraging Replicator learnings above
   - [ ] Training models with mix of real and simulated data
 - [ ] Benchmark the sim2real gap with this project, publicize results to open source community

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ factors.
     - [x] Better calibrate robots so they match position in sim to real world
     - [x] Record position of articulator in sim, not just real robot joints
     - [x] Fix bug with myarm firmware where there's a singularity at the 0 point
-    - [ ] Actually collect 50 samples
+    - [x] Actually collect 50 samples
+    - [ ] Sanity check a few episodes in the Lerobot visualizer before uploading
+    - [ ] Upload and start training
   - [x] Create a RobotProtocol that emulates latency and speed of my real robot
   - [ ] Collect a small real dataset for cube->basket task
   - [ ] Train a model on synthetic data, fine-tune on real data

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ factors.
          - Frames appear synced, however when compared to real-world footage there is a speed scaling issue...
     - [x] Validate "Replay episode" works as expected with episodes collected in Isaac Sim
     - [ ] Better calibrate robots so they match position in sim to real world
-    - [ ] Record position of articulator in sim, not just real robot joints
+    - [x] Record position of articulator in sim, not just real robot joints
     - [x] Fix bug with myarm firmware where there's a singularity at the 0 point
     - [ ] Investigate high latency in myarm loop (it is higher than in lerobot branch)
   - [x] Create a RobotProtocol that emulates latency and speed of my real robot

--- a/isaac_src/extensions/trajectory_synth/exts/trajectory_synth/trajectory_synth/path_utils.py
+++ b/isaac_src/extensions/trajectory_synth/exts/trajectory_synth/trajectory_synth/path_utils.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
 
-def get_next_numbered_dir(contains_numbered_dirs: Path, prefix: str) -> Path:
-    """Get the next directory within path assuming there exist directories with names
+def get_next_number_in_dir(contains_numbered_dirs: Path, prefix: str) -> int:
+    """Get the next number within path assuming there exist directories with names
     like "dir_001"."""
     contains_numbered_dirs.mkdir(parents=True, exist_ok=True)
     existing_numbered_dirs = [
@@ -10,7 +10,13 @@ def get_next_numbered_dir(contains_numbered_dirs: Path, prefix: str) -> Path:
         for p in contains_numbered_dirs.iterdir()
         if p.is_dir()
     ]
-    next_number = max(existing_numbered_dirs, default=0) + 1
+    return max(existing_numbered_dirs, default=0) + 1
+
+
+def get_next_numbered_dir(contains_numbered_dirs: Path, prefix: str) -> Path:
+    """Get the next directory within path assuming there exist directories with names
+    like "dir_001"."""
+    next_number = get_next_number_in_dir(contains_numbered_dirs, prefix)
     return contains_numbered_dirs / f"{prefix}_{next_number:03d}"
 
 

--- a/isaac_src/extensions/trajectory_synth/exts/trajectory_synth/trajectory_synth/renderer.py
+++ b/isaac_src/extensions/trajectory_synth/exts/trajectory_synth/trajectory_synth/renderer.py
@@ -73,7 +73,7 @@ class TrajectoryRendererExtension(omni.ext.IExt):
 
             # Number of Renders Input
             with ui.HStack(spacing=10):
-                ui.Label("Number of Renders:", width=150)
+                ui.Label("Target Number of Renders:", width=150)
                 self.num_renders_field = ui.IntField()
                 self.num_renders_field.model.set_value(1)
 
@@ -131,12 +131,32 @@ class TrajectoryRendererExtension(omni.ext.IExt):
             episodes = [episode_chosen]
 
         # For each episode, render the episode num_renders times
-        for episode_number in episodes:
-            for i in range(num_renders):
+        for i in range(num_renders):
+            for episode_number in episodes:
                 self.update_status(f"Starting render {i + 1} of {num_renders}...")
+                recordings_dir = Path(
+                    self.recordings_dir_field.model.get_value_as_string()
+                )
+                episode_path = recordings_dir / f"episode_{episode_number:03d}"
+                traj_recording = EpisodeRecording(episode_path)
+
+                next_render_number = path_utils.get_next_number_in_dir(
+                    traj_recording.renders_dir, "render"
+                )
+                if next_render_number >= i:
+                    self.update_status(
+                        f"Skipping episode {episode_number} in favor of other episodes."
+                    )
+                    continue
+
+                render_path = path_utils.get_next_numbered_dir(
+                    traj_recording.renders_dir, "render"
+                )
+
                 try:
                     await self.replay_episode(
-                        episode_number=episode_number,
+                        traj_recording=traj_recording,
+                        render_path=render_path,
                         render_index=i,
                         randomization_config=randomization_config,
                     )
@@ -150,21 +170,17 @@ class TrajectoryRendererExtension(omni.ext.IExt):
 
     async def replay_episode(
         self,
-        episode_number: int,
+        traj_recording: EpisodeRecording,
+        render_path: Path,
         render_index: int,
         randomization_config: schemas.RandomizationDistributions,
     ) -> None:
         # Get user inputs
-        recordings_dir = Path(self.recordings_dir_field.model.get_value_as_string())
         resolution_width = self.resolution_width_field.model.get_value_as_int()
         resolution_height = self.resolution_height_field.model.get_value_as_int()
 
         # Create paths and recording objects
-        episode_path = recordings_dir / f"episode_{episode_number:03d}"
-        traj_recording = EpisodeRecording(episode_path)
-        render_path = path_utils.get_next_numbered_dir(
-            traj_recording.renders_dir, "render"
-        )
+
         joints_recording = LeRobotEpisodeRecording(
             render_dir=render_path,
             recording=traj_recording.joints_recording,
@@ -231,7 +247,8 @@ class TrajectoryRendererExtension(omni.ext.IExt):
 
             joints_recording.add_timestep(current_time)
             self.update_status(
-                f"Rendering frame {frame_index}/{final_frame} of render {render_index}"
+                f"Rendering frame {frame_index}/{final_frame}. Render: {render_index} "
+                f"Episode: {traj_recording.directory.name}"
             )
 
         timeline.stop()
@@ -239,7 +256,7 @@ class TrajectoryRendererExtension(omni.ext.IExt):
 
         joints_recording.save()
 
-        self.update_status(f"Render {render_index + 1} completed.")
+        self.update_status(f"Render {render_index} completed.")
 
     def get_cameras_from_names(self, selected_camera_names: list[str]):
         available_cameras = self.get_stage_prims("Camera")

--- a/isaac_src/extensions/trajectory_synth/exts/trajectory_synth/trajectory_synth/renderer.py
+++ b/isaac_src/extensions/trajectory_synth/exts/trajectory_synth/trajectory_synth/renderer.py
@@ -347,7 +347,7 @@ class TrajectoryRendererExtension(omni.ext.IExt):
         ]
         rep.create.light(
             rotation=rep.distribution.uniform((0, -180, -180), (0, 180, 180)),
-            intensity=rep.distribution.normal(400, 200),
+            intensity=rep.distribution.uniform(50, 1200),
             temperature=rep.distribution.normal(6500, 1000),
             light_type="dome",
             texture=rep.distribution.choice(skylight_textures),

--- a/isaac_src/extensions/trajectory_synth/exts/trajectory_synth/trajectory_synth/schemas/domain_randomization.py
+++ b/isaac_src/extensions/trajectory_synth/exts/trajectory_synth/trajectory_synth/schemas/domain_randomization.py
@@ -51,8 +51,8 @@ class RandomizationDistributions(BaseModel):
     max_materials: int = 50
 
     # Choose how much to modify lighting position
-    light_pos_offset: tuple[float, float, float] = (0.1, 0.1, 0.1)
-    light_rot_offset: tuple[float, float, float] = (45, 45, 45)
+    light_pos_offset: tuple[float, float, float] = (0.5, 0.5, 0.5)
+    light_rot_offset: tuple[float, float, float] = (90, 90, 90)
 
     # Choose how to modify different prims in the scene
     distractor_params: dict[str, DistractorDistribution] = {

--- a/isaac_src/extensions/trajectory_synth/exts/trajectory_synth/trajectory_synth/schemas/episode_files.py
+++ b/isaac_src/extensions/trajectory_synth/exts/trajectory_synth/trajectory_synth/schemas/episode_files.py
@@ -1,12 +1,20 @@
+from typing import Literal
+
 from pydantic import BaseModel
 
 
 class RobotTimeSample(BaseModel):
     """A recording for a single robot, for a single episode"""
 
-    joint_positions: list[float]
+    real_joint_positions: list[float]
+    sim_joint_positions: list[float]
     isaac_time: float
     ros_time: float
+
+    def from_source(self, source: Literal["real", "sim"]) -> list[float]:
+        return (
+            self.real_joint_positions if source == "real" else self.sim_joint_positions
+        )
 
 
 class RobotRecording(BaseModel):
@@ -34,8 +42,10 @@ class TrajectoryRecordingMeta(BaseModel):
 class LeRobotTimestep(BaseModel):
     """Closely mimics one row of a episode *.parquet file from a lerobot dataset"""
 
-    action: list[float]
-    state: list[float]
+    ros_action: list[float]
+    sim_action: list[float]
+    ros_state: list[float]
+    sim_state: list[float]
     timestamp: float
     frame_index: int
     episode_index: int

--- a/pkgs/myarm_ai/myarm_ai/datasets/traj_synth/reader.py
+++ b/pkgs/myarm_ai/myarm_ai/datasets/traj_synth/reader.py
@@ -80,10 +80,11 @@ class RenderReader:
                 obs_dir.name: self._image_for_observation(step["frame_index"], obs_dir)
                 for obs_dir in self._observation_paths
             }
+            # TODO: Whether joints are pulled from 'ros' or 'sim' should be configurable
             yield Timestep(
                 images=images,
-                action=step["action"],
-                state=step["state"],  # type: ignore
+                action=step["ros_action"],
+                state=step["ros_state"],  # type: ignore
                 timestamp=step["timestamp"],
             )
 

--- a/pkgs/myarm_ai/myarm_ai/robot_protocols/__init__.py
+++ b/pkgs/myarm_ai/myarm_ai/robot_protocols/__init__.py
@@ -3,3 +3,4 @@ from .dummy_bouncing_robot import DummyBouncingRobot
 from .dummy_copycat_robot import DummyCopycatRobot
 from .myarm_follower import MyArmFollowerRobot
 from .myarm_leader import MyArmLeaderRobot
+from .threaded_follower import ThreadedReaderWriterRobot

--- a/pkgs/myarm_ai/myarm_ai/robot_protocols/threaded_follower.py
+++ b/pkgs/myarm_ai/myarm_ai/robot_protocols/threaded_follower.py
@@ -1,4 +1,3 @@
-import logging
 from threading import Event, RLock, Thread
 
 from pydantic import BaseModel
@@ -44,10 +43,8 @@ class ThreadedReaderWriterRobot(BaseRobotProtocol):
                 self._last_joints_read = self._robot.read_joints()
                 if self._last_write_request is not None:
                     joints, speed = self._last_write_request
-                    logging.info(f"Write joints: {joints} at speed {speed}")
 
                     if joints != self._last_joints_read:
-                        logging.info(f"Writing joints: {joints}")
                         self._robot.write_joints(joints, speed)
                     self._last_write_request = None
 

--- a/pkgs/myarm_ai/myarm_ai/robot_protocols/threaded_follower.py
+++ b/pkgs/myarm_ai/myarm_ai/robot_protocols/threaded_follower.py
@@ -1,0 +1,70 @@
+import logging
+from threading import Event, RLock, Thread
+
+from pydantic import BaseModel
+
+from .base_robot_protocol import BaseRobotProtocol
+from .myarm_follower import MyArmFollowerRobot
+
+
+class ThreadedReaderWriterRobot(BaseRobotProtocol):
+    """An optimized BaseRobotProtocol wrapper that is optimized for fulfulling the role
+    of a follower robot, which requires fast 'read' AND 'writes'.
+
+    It has three optimizations:
+    - Is constantly calling the underlying 'read_joints' method and caching it
+    - Calls write_joints ASAP after receiving a message
+    - Avoids calling write_joints if the joints are the same as the last message
+    """
+
+    class Parameters(BaseModel):
+        robot_protocol: type[BaseRobotProtocol] = MyArmFollowerRobot
+
+    def __init__(self, parameters: Parameters | None = None):
+        super().__init__()
+
+        self.params = parameters or self.Parameters()
+        self._robot = self.params.robot_protocol()
+
+        # Hold the last known joint positions of this robot
+        self._last_joints_read: list[float] = self._robot.read_joints()
+
+        # Hold the last requested position and speed to move to
+        self._last_write_request: tuple[list[float], float] | None = None
+
+        # Threading
+        self._thread = Thread(target=self._server_loop)
+        self._handle_lock = RLock()
+        self._exit_event = Event()
+        self._thread.start()
+
+    def _server_loop(self) -> None:
+        while not self._exit_event.is_set():
+            with self._handle_lock:
+                self._last_joints_read = self._robot.read_joints()
+                if self._last_write_request is not None:
+                    joints, speed = self._last_write_request
+                    logging.info(f"Write joints: {joints} at speed {speed}")
+
+                    if joints != self._last_joints_read:
+                        logging.info(f"Writing joints: {joints}")
+                        self._robot.write_joints(joints, speed)
+                    self._last_write_request = None
+
+    def connect(self) -> None:
+        with self._handle_lock:
+            self._robot.connect()
+
+    def deactivate_servos(self) -> None:
+        with self._handle_lock:
+            self._robot.deactivate_servos()
+
+    def read_joints(self) -> list[float]:
+        return self._last_joints_read
+
+    def write_joints(self, joints: list[float], speed: float) -> None:
+        self._last_write_request = (joints, speed)
+
+    def close(self) -> None:
+        self._exit_event.set()
+        self._thread.join()

--- a/pkgs/myarm_ai/myarm_ai_test/unit/robot_protocols/test_threaded_follower.py
+++ b/pkgs/myarm_ai/myarm_ai_test/unit/robot_protocols/test_threaded_follower.py
@@ -12,7 +12,7 @@ from node_helpers.timing import TestingTimeout
 
 
 @pytest.fixture()
-def mock_robot():
+def mock_robot() -> MagicMock:
     """Create a mock for the underlying BaseRobotProtocol."""
     mock = MagicMock(spec=BaseRobotProtocol)
     mock.read_joints.return_value = [0.0, 0.0, 0.0]
@@ -35,43 +35,49 @@ def threaded_robot(
     assert not robot._thread.is_alive()
 
 
-def test_read_joints_returns_cached_values(threaded_robot: ThreadedReaderWriterRobot):
+def test_read_joints_returns_cached_values(
+    threaded_robot: ThreadedReaderWriterRobot, mock_robot: MagicMock
+) -> None:
     """Ensure read_joints quickly returns the cached last-known joints."""
     with threaded_robot._handle_lock:
-        threaded_robot._robot.read_joints.reset_mock()
+        mock_robot.read_joints.reset_mock()
         initial_read = threaded_robot.read_joints()
         assert initial_read == [0.0, 0.0, 0.0]
-        threaded_robot._robot.read_joints.assert_not_called()  # Because the separate thread does the actual read
+
+        # Because the separate thread does the actual read
+        mock_robot.read_joints.assert_not_called()
 
     # Wait a bit to let the background thread do at least one read call.
     timeout = TestingTimeout(0.1)
-    while timeout and threaded_robot._robot.read_joints.call_count == 0:
+    while timeout and mock_robot.read_joints.call_count == 0:
         time.sleep(0.01)
 
     # The background thread calls read_joints, so mock should have been called.
-    assert threaded_robot._robot.read_joints.call_count > 0
+    assert mock_robot.read_joints.call_count > 0
 
 
 def test_write_joints_sets_last_write_request(
-    threaded_robot: ThreadedReaderWriterRobot,
-):
+    threaded_robot: ThreadedReaderWriterRobot, mock_robot: MagicMock
+) -> None:
     """Check that calling write_joints caches the request."""
     with threaded_robot._handle_lock:
-        threaded_robot._robot.write_joints.reset_mock()
+        mock_robot.write_joints.reset_mock()
         threaded_robot.write_joints([1.0, 2.0, 3.0], speed=0.5)
         # Check that we haven't immediately written to the robot
-        threaded_robot._robot.write_joints.assert_not_called()
+        mock_robot.write_joints.assert_not_called()
         assert threaded_robot._last_write_request == ([1.0, 2.0, 3.0], 0.5)
 
     timeout = TestingTimeout(0.1)
-    while timeout and threaded_robot._robot.write_joints.call_count == 0:
+    while timeout and mock_robot.write_joints.call_count == 0:
         time.sleep(0.01)
 
-    threaded_robot._robot.write_joints.assert_called_once()
-    threaded_robot._robot.write_joints.assert_called_once_with([1.0, 2.0, 3.0], 0.5)
+    mock_robot.write_joints.assert_called_once()
+    mock_robot.write_joints.assert_called_once_with([1.0, 2.0, 3.0], 0.5)
 
 
-def test_thread_avoids_write_if_joints_same(threaded_robot: ThreadedReaderWriterRobot):
+def test_thread_avoids_write_if_joints_same(
+    threaded_robot: ThreadedReaderWriterRobot, mock_robot: MagicMock
+) -> None:
     """
     If the new write_joints request is the same as the last read,
     the background thread won't call write_joints.
@@ -79,16 +85,16 @@ def test_thread_avoids_write_if_joints_same(threaded_robot: ThreadedReaderWriter
     # By default, mock_robot.read_joints() -> [0.0, 0.0, 0.0]
     # So let's "wait" for at least one read
     timeout = TestingTimeout(0.1)
-    while timeout and threaded_robot._robot.read_joints.call_count == 0:
+    while timeout and mock_robot.read_joints.call_count == 0:
         time.sleep(0.01)
 
     # Now the last known read is [0.0, 0.0, 0.0].
     # If we request a write to the same [0.0, 0.0, 0.0], it should skip.
     threaded_robot.write_joints([0.0, 0.0, 0.0], 1.0)
-    threaded_robot._robot.write_joints.assert_not_called()
+    mock_robot.write_joints.assert_not_called()
 
 
-def test_close_joins_thread(threaded_robot):
+def test_close_joins_thread(threaded_robot: ThreadedReaderWriterRobot) -> None:
     threaded_robot.close()
 
     assert not threaded_robot._thread.is_alive()

--- a/pkgs/myarm_ai/myarm_ai_test/unit/robot_protocols/test_threaded_follower.py
+++ b/pkgs/myarm_ai/myarm_ai_test/unit/robot_protocols/test_threaded_follower.py
@@ -1,0 +1,94 @@
+import time
+from collections.abc import Generator
+from unittest.mock import MagicMock
+
+import pytest
+from myarm_ai.robot_protocols import (
+    BaseRobotProtocol,
+    DummyCopycatRobot,
+    ThreadedReaderWriterRobot,
+)
+from node_helpers.timing import TestingTimeout
+
+
+@pytest.fixture()
+def mock_robot():
+    """Create a mock for the underlying BaseRobotProtocol."""
+    mock = MagicMock(spec=BaseRobotProtocol)
+    mock.read_joints.return_value = [0.0, 0.0, 0.0]
+    return mock
+
+
+@pytest.fixture()
+def threaded_robot(
+    mock_robot: MagicMock,
+) -> Generator[ThreadedReaderWriterRobot, None, None]:
+    robot = ThreadedReaderWriterRobot(
+        parameters=ThreadedReaderWriterRobot.Parameters(
+            robot_protocol=DummyCopycatRobot
+        )
+    )
+    robot._robot = mock_robot
+    yield robot
+
+    robot.close()
+    assert not robot._thread.is_alive()
+
+
+def test_read_joints_returns_cached_values(threaded_robot: ThreadedReaderWriterRobot):
+    """Ensure read_joints quickly returns the cached last-known joints."""
+    with threaded_robot._handle_lock:
+        threaded_robot._robot.read_joints.reset_mock()
+        initial_read = threaded_robot.read_joints()
+        assert initial_read == [0.0, 0.0, 0.0]
+        threaded_robot._robot.read_joints.assert_not_called()  # Because the separate thread does the actual read
+
+    # Wait a bit to let the background thread do at least one read call.
+    timeout = TestingTimeout(0.1)
+    while timeout and threaded_robot._robot.read_joints.call_count == 0:
+        time.sleep(0.01)
+
+    # The background thread calls read_joints, so mock should have been called.
+    assert threaded_robot._robot.read_joints.call_count > 0
+
+
+def test_write_joints_sets_last_write_request(
+    threaded_robot: ThreadedReaderWriterRobot,
+):
+    """Check that calling write_joints caches the request."""
+    with threaded_robot._handle_lock:
+        threaded_robot._robot.write_joints.reset_mock()
+        threaded_robot.write_joints([1.0, 2.0, 3.0], speed=0.5)
+        # Check that we haven't immediately written to the robot
+        threaded_robot._robot.write_joints.assert_not_called()
+        assert threaded_robot._last_write_request == ([1.0, 2.0, 3.0], 0.5)
+
+    timeout = TestingTimeout(0.1)
+    while timeout and threaded_robot._robot.write_joints.call_count == 0:
+        time.sleep(0.01)
+
+    threaded_robot._robot.write_joints.assert_called_once()
+    threaded_robot._robot.write_joints.assert_called_once_with([1.0, 2.0, 3.0], 0.5)
+
+
+def test_thread_avoids_write_if_joints_same(threaded_robot: ThreadedReaderWriterRobot):
+    """
+    If the new write_joints request is the same as the last read,
+    the background thread won't call write_joints.
+    """
+    # By default, mock_robot.read_joints() -> [0.0, 0.0, 0.0]
+    # So let's "wait" for at least one read
+    timeout = TestingTimeout(0.1)
+    while timeout and threaded_robot._robot.read_joints.call_count == 0:
+        time.sleep(0.01)
+
+    # Now the last known read is [0.0, 0.0, 0.0].
+    # If we request a write to the same [0.0, 0.0, 0.0], it should skip.
+    threaded_robot.write_joints([0.0, 0.0, 0.0], 1.0)
+    threaded_robot._robot.write_joints.assert_not_called()
+
+
+def test_close_joins_thread(threaded_robot):
+    threaded_robot.close()
+
+    assert not threaded_robot._thread.is_alive()


### PR DESCRIPTION
A few critical changes I made as I went through this first big step:

- [x] Added recording of the 'sim' robot joints, not just the 'real' follower and controller. This give's me flexibility so I can re-export the lerobot dataset later on and use a mix of 'real' or 'sim' joints, for different experiments.
- [x] A few usability fixes to the rendering extension. It now does 'breadth first' rendering, preferring to render unique episodes first instead of fixating on one episode until it reaches the target # of renders.
- [x] Massive improvements to control latency for the myarm. Went from 0.31s to 0.11s, using better QOS, and writing an async reader/writer for the serial controls. Unfortunately I can't edit the firmware, which I believe to be the current bottleneck.